### PR TITLE
Models to be public - To allow module extension

### DIFF
--- a/Sources/BlogModule/BlogModule.swift
+++ b/Sources/BlogModule/BlogModule.swift
@@ -8,25 +8,25 @@
 import Fluent
 import FeatherCore
 
-final class BlogModule: ViperModule {
+final public class BlogModule: ViperModule {
 
-    static let name = "blog"
-    var priority: Int { 1100 }
+    static public let name = "blog"
+    public var priority: Int { 1100 }
 
-    var router: ViperRouter? = BlogRouter()
+    public var router: ViperRouter? = BlogRouter()
     
 
-    var migrations: [Migration] {
+    public var migrations: [Migration] {
         [
             BlogMigration_v1_0_0(),
         ]
     }
   
-    static var bundleUrl: URL? {
+    static public var bundleUrl: URL? {
         Bundle.module.resourceURL?.appendingPathComponent("Bundle")
     }
 
-    func boot(_ app: Application) throws {
+    public func boot(_ app: Application) throws {
         /// frontend middleware
         app.databases.middleware.use(FrontendMetadataMiddleware<BlogPostModel>())
         app.databases.middleware.use(FrontendMetadataMiddleware<BlogCategoryModel>())

--- a/Sources/BlogModule/Models/BlogAuthorLinkModel+View.swift
+++ b/Sources/BlogModule/Models/BlogAuthorLinkModel+View.swift
@@ -9,7 +9,7 @@ import FeatherCore
 
 extension BlogAuthorLinkModel: LeafDataRepresentable {
     
-    var leafData: LeafData {
+    public var leafData: LeafData {
         .dictionary([
             "id": id,
             "name": name,

--- a/Sources/BlogModule/Models/BlogAuthorLinkModel.swift
+++ b/Sources/BlogModule/Models/BlogAuthorLinkModel.swift
@@ -7,10 +7,10 @@
 
 import FeatherCore
 
-final class BlogAuthorLinkModel: ViperModel {
-    typealias Module = BlogModule
+final public class BlogAuthorLinkModel: ViperModel {
+    public typealias Module = BlogModule
 
-    static let name = "links"
+    static public let name = "links"
     
     struct FieldKeys {
         static var name: FieldKey { "name" }
@@ -21,19 +21,19 @@ final class BlogAuthorLinkModel: ViperModel {
     
     // MARK: - fields
 
-    @ID() var id: UUID?
-    @Field(key: FieldKeys.name) var name: String
-    @Field(key: FieldKeys.url) var url: String
-    @Field(key: FieldKeys.priority) var priority: Int
-    @Parent(key: FieldKeys.authorId) var author: BlogAuthorModel
+    @ID() public var id: UUID?
+    @Field(key: FieldKeys.name) public var name: String
+    @Field(key: FieldKeys.url) public var url: String
+    @Field(key: FieldKeys.priority) public var priority: Int
+    @Parent(key: FieldKeys.authorId) public var author: BlogAuthorModel
     
-    init() { }
+    public init() { }
     
-    init(id: UUID? = nil,
-         name: String,
-         url: String,
-         priority: Int = 10,
-         authorId: UUID)
+    public init( id: UUID? = nil,
+                 name: String,
+                 url: String,
+                 priority: Int = 10,
+                 authorId: UUID)
     {
         self.id = id
         self.name = name

--- a/Sources/BlogModule/Models/BlogAuthorModel+Metadata.swift
+++ b/Sources/BlogModule/Models/BlogAuthorModel+Metadata.swift
@@ -9,9 +9,9 @@ import FeatherCore
 
 extension BlogAuthorModel: FrontendMetadataChangeDelegate {
 
-    var slug: String { Self.name + "/" + name.slugify() }
+    public var slug: String { Self.name + "/" + name.slugify() }
 
-    func willUpdate(_ metadata: FrontendMetadata) {
+    public func willUpdate(_ metadata: FrontendMetadata) {
         metadata.slug = slug
         metadata.title = name
         metadata.excerpt = bio

--- a/Sources/BlogModule/Models/BlogAuthorModel+Query.swift
+++ b/Sources/BlogModule/Models/BlogAuthorModel+Query.swift
@@ -9,7 +9,7 @@ import FeatherCore
 
 extension BlogAuthorModel {
 
-    static func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogAuthorModel> {
+    static public func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogAuthorModel> {
         query(on: req.db)
             .filter(\.$id == id)
             .with(\.$links)
@@ -17,7 +17,7 @@ extension BlogAuthorModel {
             .unwrap(or: Abort(.notFound))
     }
 
-    static func findPublished(on req: Request) -> EventLoopFuture<[BlogAuthorModel]> {
+    static public func findPublished(on req: Request) -> EventLoopFuture<[BlogAuthorModel]> {
         findMetadata(on: req.db)
             .filter(FrontendMetadata.self, \.$status == .published)
             .filter(FrontendMetadata.self, \.$date <= Date())

--- a/Sources/BlogModule/Models/BlogAuthorModel+View.swift
+++ b/Sources/BlogModule/Models/BlogAuthorModel+View.swift
@@ -9,7 +9,7 @@ import FeatherCore
 
 extension BlogAuthorModel: LeafDataRepresentable {
 
-    var leafData: LeafData {
+    public var leafData: LeafData {
         .dictionary([
             "id": id,
             "name": name,
@@ -23,7 +23,7 @@ extension BlogAuthorModel: LeafDataRepresentable {
 
 extension BlogAuthorModel: FormFieldOptionRepresentable {
 
-    var formFieldOption: FormFieldOption {
+    public var formFieldOption: FormFieldOption {
         .init(key: id!.uuidString, label: name)
     }
 }

--- a/Sources/BlogModule/Models/BlogAuthorModel.swift
+++ b/Sources/BlogModule/Models/BlogAuthorModel.swift
@@ -7,33 +7,33 @@
 
 import FeatherCore
 
-final class BlogAuthorModel: ViperModel {
+final public class BlogAuthorModel: ViperModel {
 
-    typealias Module = BlogModule
+    public typealias Module = BlogModule
     
-    static let name = "authors"
+    public static let name = "authors"
     
-    struct FieldKeys {
-        static var name: FieldKey { "name" }
-        static var imageKey: FieldKey { "imageKey" }
-        static var bio: FieldKey { "bio" }
+    public struct FieldKeys {
+            static public var name: FieldKey { "name" }
+            static public var imageKey: FieldKey { "imageKey" }
+            static public var bio: FieldKey { "bio" }
     }
 
     // MARK: - fields
 
-    @ID() var id: UUID?
-    @Field(key: FieldKeys.name) var name: String
-    @Field(key: FieldKeys.imageKey) var imageKey: String
-    @Field(key: FieldKeys.bio) var bio: String
-    @Children(for: \.$author) var links: [BlogAuthorLinkModel]
-    @Children(for: \.$author) var posts: [BlogPostModel]
+    @ID() public var id: UUID?
+    @Field(key: FieldKeys.name) public var name: String
+    @Field(key: FieldKeys.imageKey) public var imageKey: String
+    @Field(key: FieldKeys.bio) public var bio: String
+    @Children(for: \.$author) public var links: [BlogAuthorLinkModel]
+    @Children(for: \.$author) public var posts: [BlogPostModel]
     
-    init() { }
+    public init() { }
     
-    init(id: UUID? = nil,
-         name: String,
-         imageKey: String,
-         bio: String)
+    public init( id: UUID? = nil,
+                 name: String,
+                 imageKey: String,
+                 bio: String)
     {
         self.id = id
         self.name = name

--- a/Sources/BlogModule/Models/BlogCategoryModel+Metadata.swift
+++ b/Sources/BlogModule/Models/BlogCategoryModel+Metadata.swift
@@ -11,10 +11,10 @@ import FeatherCore
 extension BlogCategoryModel: FrontendMetadataChangeDelegate {
     
     /// the default slug is just a combination of the model name and the slugified title
-    var slug: String { Self.name + "/" + title.slugify() }
+    public var slug: String { Self.name + "/" + title.slugify() }
     
     /// when a category change happens we update the slug and title of the associated metadata
-    func willUpdate(_ metadata: FrontendMetadata) {
+    public func willUpdate(_ metadata: FrontendMetadata) {
         metadata.slug = slug
         metadata.title = title
     }

--- a/Sources/BlogModule/Models/BlogCategoryModel+Query.swift
+++ b/Sources/BlogModule/Models/BlogCategoryModel+Query.swift
@@ -9,11 +9,11 @@ import FeatherCore
 
 extension BlogCategoryModel {
 
-    static func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogCategoryModel> {
+    static public func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogCategoryModel> {
         find(id, on: req.db).unwrap(or: Abort(.notFound))
     }
 
-    static func findPublished(on req: Request) -> EventLoopFuture<[BlogCategoryModel]> {
+    static public func findPublished(on req: Request) -> EventLoopFuture<[BlogCategoryModel]> {
         findMetadata(on: req.db)
             .filter(FrontendMetadata.self, \.$status == .published)
             .filter(FrontendMetadata.self, \.$date <= Date())

--- a/Sources/BlogModule/Models/BlogCategoryModel+View.swift
+++ b/Sources/BlogModule/Models/BlogCategoryModel+View.swift
@@ -9,7 +9,7 @@ import FeatherCore
 
 extension BlogCategoryModel: LeafDataRepresentable {
 
-    var leafData: LeafData {
+    public var leafData: LeafData {
         .dictionary([
             "id": id,
             "title": title,
@@ -24,7 +24,7 @@ extension BlogCategoryModel: LeafDataRepresentable {
 
 extension BlogCategoryModel: FormFieldOptionRepresentable {
 
-    var formFieldOption: FormFieldOption {
+    public var formFieldOption: FormFieldOption {
         .init(key: id!.uuidString, label: title)
     }
 }

--- a/Sources/BlogModule/Models/BlogCategoryModel.swift
+++ b/Sources/BlogModule/Models/BlogCategoryModel.swift
@@ -7,10 +7,10 @@
 
 import FeatherCore
 
-final class BlogCategoryModel: ViperModel {
-    typealias Module = BlogModule
+final public class BlogCategoryModel: ViperModel {
+    public typealias Module = BlogModule
 
-    static let name = "categories"
+    public static let name = "categories"
     
     struct FieldKeys {
         static var title: FieldKey { "title" }
@@ -20,22 +20,22 @@ final class BlogCategoryModel: ViperModel {
         static var priority: FieldKey { "priority" }
     }
 
-    @ID() var id: UUID?
-    @Field(key: FieldKeys.title) var title: String
-    @Field(key: FieldKeys.imageKey) var imageKey: String
-    @Field(key: FieldKeys.excerpt) var excerpt: String
-    @Field(key: FieldKeys.color) var color: String?
-    @Field(key: FieldKeys.priority) var priority: Int
-    @Children(for: \.$category) var posts: [BlogPostModel]
+    @ID() public var id: UUID?
+    @Field(key: FieldKeys.title) public var title: String
+    @Field(key: FieldKeys.imageKey) public var imageKey: String
+    @Field(key: FieldKeys.excerpt) public var excerpt: String
+    @Field(key: FieldKeys.color) public var color: String?
+    @Field(key: FieldKeys.priority) public var priority: Int
+    @Children(for: \.$category) public var posts: [BlogPostModel]
     
-    init() { }
+    public init() { }
     
-    init(id: UUID? = nil,
-         title: String,
-         imageKey: String,
-         excerpt: String,
-         color: String? = nil,
-         priority: Int = 100)
+    public init( id: UUID? = nil,
+                 title: String,
+                 imageKey: String,
+                 excerpt: String,
+                 color: String? = nil,
+                 priority: Int = 100)
     {
         self.id = id
         self.title = title

--- a/Sources/BlogModule/Models/BlogPostModel+Metadata.swift
+++ b/Sources/BlogModule/Models/BlogPostModel+Metadata.swift
@@ -9,9 +9,9 @@ import FeatherCore
 
 extension BlogPostModel: FrontendMetadataChangeDelegate {
     
-    var slug: String { title.slugify() }
+    public var slug: String { title.slugify() }
     
-    func willUpdate(_ metadata: FrontendMetadata) {
+    public func willUpdate(_ metadata: FrontendMetadata) {
         metadata.slug = slug
         metadata.title = title
         metadata.excerpt = excerpt

--- a/Sources/BlogModule/Models/BlogPostModel+Query.swift
+++ b/Sources/BlogModule/Models/BlogPostModel+Query.swift
@@ -10,7 +10,7 @@ import FeatherCore
 extension BlogPostModel {
 
     /// query posts for the home page
-    static func home(on req: Request) -> EventLoopFuture<[BlogPostModel]> {
+    static public func home(on req: Request) -> EventLoopFuture<[BlogPostModel]> {
         query(on: req.db)
             .join(FrontendMetadata.self, on: \BlogPostModel.$id == \FrontendMetadata.$reference, method: .inner)
             .filter(FrontendMetadata.self, \.$status == .published)
@@ -22,7 +22,7 @@ extension BlogPostModel {
     }
     
     /// public post list
-    static func find(on req: Request) -> QueryBuilder<BlogPostModel> {
+    static public func find(on req: Request) -> QueryBuilder<BlogPostModel> {
         findMetadata(on: req.db)
             .filter(FrontendMetadata.self, \.$status == .published)
             .filter(FrontendMetadata.self, \.$date <= Date())
@@ -31,7 +31,7 @@ extension BlogPostModel {
     }
 
     /// find a single post by metadata
-    static func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogPostModel> {
+    static public func findBy(id: UUID, on req: Request) -> EventLoopFuture<BlogPostModel> {
         findMetadata(on: req.db)
             .filter(\.$id == id)
             .with(\.$category)
@@ -41,7 +41,7 @@ extension BlogPostModel {
     }
     
     /// query posts for the author page
-    static func findByAuthor(id: UUID, on req: Request) -> EventLoopFuture<[BlogPostModel]> {
+    static public func findByAuthor(id: UUID, on req: Request) -> EventLoopFuture<[BlogPostModel]> {
         findMetadata(on: req.db)
             .filter(FrontendMetadata.self, \.$status == .published)
             .filter(FrontendMetadata.self, \.$date <= Date())
@@ -52,7 +52,7 @@ extension BlogPostModel {
     }
 
     /// query posts for the category page
-    static func findByCategory(id: UUID, on req: Request) -> EventLoopFuture<[BlogPostModel]> {
+    static public func findByCategory(id: UUID, on req: Request) -> EventLoopFuture<[BlogPostModel]> {
         findMetadata(on: req.db)
             .filter(FrontendMetadata.self, \.$status == .published)
             .filter(FrontendMetadata.self, \.$date <= Date())

--- a/Sources/BlogModule/Models/BlogPostModel+View.swift
+++ b/Sources/BlogModule/Models/BlogPostModel+View.swift
@@ -9,7 +9,7 @@ import FeatherCore
 
 extension BlogPostModel: LeafDataRepresentable {
 
-    var leafData: LeafData {
+    public var leafData: LeafData {
         .dictionary([
             "id": id,
             "title": title,

--- a/Sources/BlogModule/Models/BlogPostModel.swift
+++ b/Sources/BlogModule/Models/BlogPostModel.swift
@@ -7,10 +7,10 @@
 
 import FeatherCore
 
-final class BlogPostModel: ViperModel {
-    typealias Module = BlogModule
+final public class BlogPostModel: ViperModel {
+    public typealias Module = BlogModule
     
-    static let name = "posts"
+    public static let name = "posts"
 
     struct FieldKeys {
         static var title: FieldKey { "title" }
@@ -23,15 +23,15 @@ final class BlogPostModel: ViperModel {
     
     // MARK: - fields
 
-    @ID() var id: UUID?
-    @Field(key: FieldKeys.title) var title: String
-    @Field(key: FieldKeys.imageKey) var imageKey: String
-    @Field(key: FieldKeys.excerpt) var excerpt: String
-    @Field(key: FieldKeys.content) var content: String
-    @Parent(key: FieldKeys.categoryId) var category: BlogCategoryModel
-    @Parent(key: FieldKeys.authorId) var author: BlogAuthorModel
+    @ID() public var id: UUID?
+    @Field(key: FieldKeys.title) public var title: String
+    @Field(key: FieldKeys.imageKey) public var imageKey: String
+    @Field(key: FieldKeys.excerpt) public var excerpt: String
+    @Field(key: FieldKeys.content) public var content: String
+    @Parent(key: FieldKeys.categoryId) public var category: BlogCategoryModel
+    @Parent(key: FieldKeys.authorId) public var author: BlogAuthorModel
 
-    init() { }
+    public init() { }
     
     init(id: UUID? = nil,
          title: String,


### PR DESCRIPTION
Hello @tib ,

I was wondering if you would consider exposing your models publicly in the module Blog (May suggest the same in other module).

The idea is to be able to extend a module, in my case for exemple, I would like to extend it with some rest API as per this project
https://github.com/charlymr/blog-api

I am also planing to have some way to import data at some stage. 

Please let me know what you think.

Thanks,

Denis