### PR TITLE
Fixed implementation to use Public API

### DIFF
--- a/Sources/BlogModule/BlogRouter.swift
+++ b/Sources/BlogModule/BlogRouter.swift
@@ -25,6 +25,15 @@ struct BlogRouter: FeatherRouter {
         adminRoutes.register(authorLinkController)
     }
     
+    func apiRoutesHook(args: HookArguments) {
+        let apiRoutes = args.routes
+
+        apiRoutes.registerPublicApi(postController)
+        apiRoutes.registerPublicApi(categoryController)
+        apiRoutes.registerPublicApi(authorController)
+        apiRoutes.registerPublicApi(authorLinkController)
+    }
+    
     func apiAdminRoutesHook(args: HookArguments) {
         let apiRoutes = args.routes
 

--- a/Sources/BlogModule/BlogRouter.swift
+++ b/Sources/BlogModule/BlogRouter.swift
@@ -31,7 +31,7 @@ struct BlogRouter: FeatherRouter {
         apiRoutes.registerPublicApi(postController)
         apiRoutes.registerPublicApi(categoryController)
         apiRoutes.registerPublicApi(authorController)
-        apiRoutes.registerPublicApi(authorLinkController)
+//        apiRoutes.registerPublicApi(authorLinkController)
     }
     
     func apiAdminRoutesHook(args: HookArguments) {

--- a/Sources/BlogModule/Controllers/BlogAuthorController.swift
+++ b/Sources/BlogModule/Controllers/BlogAuthorController.swift
@@ -7,7 +7,7 @@
 
 import FeatherCore
 
-struct BlogAuthorController: FeatherController {
+struct BlogAuthorController: PublicFeatherController {
 
     typealias Module = BlogModule
     typealias Model = BlogAuthorModel

--- a/Sources/BlogModule/Controllers/BlogAuthorLinkController.swift
+++ b/Sources/BlogModule/Controllers/BlogAuthorLinkController.swift
@@ -7,7 +7,7 @@
 
 import FeatherCore
 
-struct BlogAuthorLinkController: PublicFeatherController {
+struct BlogAuthorLinkController: FeatherController {
 
     typealias Module = BlogModule
     typealias Model = BlogAuthorLinkModel

--- a/Sources/BlogModule/Controllers/BlogAuthorLinkController.swift
+++ b/Sources/BlogModule/Controllers/BlogAuthorLinkController.swift
@@ -7,7 +7,7 @@
 
 import FeatherCore
 
-struct BlogAuthorLinkController: FeatherController {
+struct BlogAuthorLinkController: PublicFeatherController {
 
     typealias Module = BlogModule
     typealias Model = BlogAuthorLinkModel

--- a/Sources/BlogModule/Controllers/BlogCategoryController.swift
+++ b/Sources/BlogModule/Controllers/BlogCategoryController.swift
@@ -7,7 +7,7 @@
 
 import FeatherCore
 
-struct BlogCategoryController: FeatherController {
+struct BlogCategoryController: PublicFeatherController {
 
     typealias Module = BlogModule
     typealias Model = BlogCategoryModel

--- a/Sources/BlogModule/Controllers/BlogPostController.swift
+++ b/Sources/BlogModule/Controllers/BlogPostController.swift
@@ -68,21 +68,18 @@ struct BlogPostController: FeatherController {
 
 /// Overide default Route Builder
 extension BlogPostController {
-    
-    func listApiTimestamp(_ req: Request) throws -> EventLoopFuture<Response> {
+
+    func listApiTimestamp(_ req: Request) throws -> EventLoopFuture<PaginationContainer<ListApi.ListObject> > {
         let start: Date = req.query["start"] ?? Date(timeIntervalSince1970: 0)
         let end: Date = req.query["end"] ?? Date()
-        let paginated =  listLoader.paginate(req, start: start, end: end, withDeleted: true).map { pc -> PaginationContainer<ListApi.ListObject> in
+        return  listLoader.paginate(req, start: start, end: end, withDeleted: true).map { pc -> PaginationContainer<ListApi.ListObject> in
                 let api = ListApi()
                 let items = pc.map { api.mapList(model: $0) }
                 return items
             }
-        var headers = HTTPHeaders()
-        headers.add(name: "X-Timestamp", value: "\(Int(Date().timeIntervalSince1970))")
-        return paginated.encodeResponse(status: .ok, headers: headers, for: req)
     }
     
-    func setupListApiRoute(on builder: RoutesBuilder) {
+    func setupListPublicApiRoute(on builder: RoutesBuilder) {
         builder.get(use: listApiTimestamp)
     }
 


### PR DESCRIPTION
@tib now using the public API route which is used by CoreData sync POC I did:
https://github.com/charlymr/IRLServerConnection

PS. I completely renamed the package; I created a base Package (FeatherConnect) and a BlogMoudle package that depends on it. It can serve a base example for other modules. 

The delta syncing depends on the timestamp and using the `listApiTimestamp`as the want to have the start/stop markers in the the URL params.

